### PR TITLE
HOPSFS-348: update to object-store 1.1.1 and bump version to 1.4.0-post1

### DIFF
--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 deltalake-core = { version = "0.30.0", path = "../core"}
-hdfs-native-object-store = { git = "https://github.com/logicalclocks/hopsfs-native-object-store.git" , branch = "1.1.0"}
+hdfs-native-object-store = { git = "https://github.com/hamidgh09/hopsfs-native-object-store.git" , branch = "HOPSFS-348"}
 
 # workspace dependencies
 tokio = { workspace = true }

--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 deltalake-core = { version = "0.30.0", path = "../core"}
-hdfs-native-object-store = { git = "https://github.com/hamidgh09/hopsfs-native-object-store.git" , branch = "HOPSFS-348"}
+hdfs-native-object-store = { git = "https://github.com/logicalclocks/hopsfs-native-object-store.git" , branch = "1.1.1"}
 
 # workspace dependencies
 tokio = { workspace = true }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.4.0"
+version = "1.4.0-post1"
 authors = [
     "Qingping Hou <dave2008713@gmail.com>",
     "Will Jones <willjones127@gmail.com>",

--- a/python/README.md
+++ b/python/README.md
@@ -23,6 +23,14 @@ dt.file_uris()
 
 See the [user guide](https://delta-io.github.io/delta-rs/usage/installation/) for more examples.
 
+## Compatibility Matrix
+
+| hops-deltalake | hops-object-store | HopsFS                              |
+|----------------|-------------------|-------------------------------------|
+| 1.1.2-post2    | 1.0.3             | 3.2.0.18                            |
+| 1.4.0          | 1.1.0             | 3.2.0.18-EE-RC1                     |
+| 1.4.0-post1    | 1.1.1             | >= 3.2.0.18-EE-RC1 < 3.4.4.0-EE-RC0 |
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
