### PR TITLE
HOPSFS-353: Bump native object store to 1.2.1 and release 1.4.0-post121

### DIFF
--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 deltalake-core = { version = "0.30.0", path = "../core"}
-hdfs-native-object-store = { git = "https://github.com/logicalclocks/hopsfs-native-object-store.git" , branch = "1.1.1"}
+hopsfs-native-object-store = "1.2.1"
 
 # workspace dependencies
 tokio = { workspace = true }
@@ -27,4 +27,4 @@ deltalake-test = { path = "../test" }
 walkdir = "2"
 
 [features]
-integration_test = ["hdfs-native-object-store/integration-test"]
+integration_test = ["hopsfs-native-object-store/integration-test"]

--- a/crates/hdfs/src/lib.rs
+++ b/crates/hdfs/src/lib.rs
@@ -5,7 +5,7 @@ use deltalake_core::logstore::{
 };
 use deltalake_core::logstore::{ObjectStoreFactory, ObjectStoreRef, object_store_factories};
 use deltalake_core::{DeltaResult, Path};
-use hdfs_native_object_store::HdfsObjectStoreBuilder;
+use hopsfs_native_object_store::HdfsObjectStoreBuilder;
 use url::Url;
 
 #[derive(Clone, Default, Debug)]

--- a/crates/hdfs/tests/context.rs
+++ b/crates/hdfs/tests/context.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "integration_test")]
 use deltalake_hdfs::register_handlers;
 use deltalake_test::utils::*;
-use hdfs_native_object_store::minidfs::MiniDfs;
+use hopsfs_native_object_store::minidfs::MiniDfs;
 use std::{
     collections::HashSet,
     process::{Command, ExitStatus},

--- a/hops-deploy.jenkinsfile
+++ b/hops-deploy.jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                     ).trim()
                     echo "Extracted delta-rs version: ${DELTA_RS_VERSION}"
                     HOPS_NATIVE_BRANCH = sh(
-                        script: "grep 'hdfs-native-object-store' crates/hdfs/Cargo.toml | grep 'branch' | sed -n 's/.*branch *= *\"\\([^\"]*\\)\".*/\\1/p'",
+                        script: "grep 'hopsfs-native-object-store' crates/hdfs/Cargo.toml | grep 'branch' | sed -n 's/.*branch *= *\"\\([^\"]*\\)\".*/\\1/p'",
                         returnStdout: true
                     ).trim()
                     echo "Extracted hops native object store version: ${HOPS_NATIVE_BRANCH}"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.4.0-post1"
+version = "1.4.0-post121"
 authors = [
     "Qingping Hou <dave2008713@gmail.com>",
     "Will Jones <willjones127@gmail.com>",


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
