### PR TITLE
HOPSFS-323: bump native object store and version to 1.4.0-post131

### DIFF
--- a/crates/hdfs/Cargo.toml
+++ b/crates/hdfs/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 deltalake-core = { version = "0.30.0", path = "../core"}
-hopsfs-native-object-store = "1.2.1"
+hopsfs-native-object-store = "1.3.1"
 
 # workspace dependencies
 tokio = { workspace = true }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltalake-python"
-version = "1.4.0-post121"
+version = "1.4.0-post131"
 authors = [
     "Qingping Hou <dave2008713@gmail.com>",
     "Will Jones <willjones127@gmail.com>",


### PR DESCRIPTION
# Description
The description of the main changes of your pull request

# Related Issue(s)
<!---
For example:

- closes #106
--->

# Documentation

<!---
Share links to useful documentation
--->
